### PR TITLE
Fix localization plugin configuration cache incompatibility

### DIFF
--- a/localization/src/main/kotlin/ca/stellardrift/build/localization/LocalizationPlugin.kt
+++ b/localization/src/main/kotlin/ca/stellardrift/build/localization/LocalizationPlugin.kt
@@ -55,8 +55,6 @@ open class LocalizationExtension @Inject constructor(objects: ObjectFactory) {
 }
 
 abstract class LocalizationGenerate : DefaultTask() {
-    private val templateEngine = StreamingTemplateEngine()
-
     @get:Inject
     abstract val objectFactory: ObjectFactory
 
@@ -84,7 +82,7 @@ abstract class LocalizationGenerate : DefaultTask() {
 
     @TaskAction
     fun generateSources() {
-        val template = templateEngine.createTemplate(templateFile.get().asFile)
+        val template = StreamingTemplateEngine().createTemplate(templateFile.get().asFile)
         tree.visit {
             if (it.isDirectory) {
                 return@visit


### PR DESCRIPTION
The template engine stores it's ClassLoader which can't be serialized